### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ useServer((server) => {
 },(url:string)=>{
     // It is optional 
     // You can block some requests to prevent them from being processed by SveltetKit
-    // return (url.startWidth('hello'))
+    // return (url.startsWith('hello'))
     return false
 })
 


### PR DESCRIPTION
Found a small typo in the README.md file